### PR TITLE
Move getting of props to from JS to component

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,16 +24,6 @@ export const componentDouble = original => {
         value => (value instanceof Function) && value.name === fnName);
       updateFn(value);
     }
-
-    getNonSpyProps() {
-      const allProps = this.$$.ctx[3];
-      return Object.keys(allProps).reduce((acc, key) => {
-        if (!key.startsWith("_spy")) {
-          acc[key] = allProps[key];
-        }
-        return acc;
-      }, {});
-    }
   }
 
   TestComponent.toString = () => (

--- a/lib/ComponentDouble.svelte
+++ b/lib/ComponentDouble.svelte
@@ -2,7 +2,6 @@
   const { _spyName: name, _spyInstance: instance, otherProps } = $$props;
 
   export function getNonSpyProps() {
-    const allProps = this.$$.ctx[3];
     return Object.keys($$props).reduce((acc, key) => {
       if (!key.startsWith("_spy")) {
         acc[key] = $$props[key];

--- a/lib/ComponentDouble.svelte
+++ b/lib/ComponentDouble.svelte
@@ -1,5 +1,15 @@
 <script>
   const { _spyName: name, _spyInstance: instance, otherProps } = $$props;
+
+  export function getNonSpyProps() {
+    const allProps = this.$$.ctx[3];
+    return Object.keys($$props).reduce((acc, key) => {
+      if (!key.startsWith("_spy")) {
+        acc[key] = $$props[key];
+      }
+      return acc;
+    }, {});
+  }
 </script>
 
 <script context="module">


### PR DESCRIPTION
Hello, maybe only in recent svelte versions, acessing `this.$$.ctx[3]` no longer works. I moved the function into the component itself and thus it is more future-proof and not susceptible to changes to svelte runtime internals.