### PR TITLE
Fix "missing-exports-condition" warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "svelte": "index.js",
   "type": "module",
   "exports": {
-    ".": "./index.js",
+    ".": {
+      "import": "./index.js",
+      "svelte": "./index.js"
+    },
     "./vitest": "./matchers/vitest.js"
   },
   "repository": {


### PR DESCRIPTION
I have been getting this warning when using `svelte-component-double`:
```
svelte-component-double@2.0.0

Please see https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition for details.
11:16:21 AM [vite-plugin-svelte] WARNING: The following packages have a svelte field in their package.json but no exports condition for svelte.
```
This little tweak in `package.json` fixes it.
Thank you